### PR TITLE
Fix: Standardize Twitter/X links to ethereum_chile

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -102,7 +102,7 @@ const Footer = () => {
 
             <div className="lg:hidden grid grid-cols-2 gap-4 justify-items-center">
               <div className="text-2xl">
-                <FlipLink href="https://x.com/Ethereum_Chile" text="Twitter">
+                <FlipLink href="https://x.com/ethereum_chile" text="Twitter">
                   Twitter
                 </FlipLink>
               </div>
@@ -128,7 +128,7 @@ const Footer = () => {
 
             <div className="hidden lg:flex flex-col space-y-6">
               <div className="text-3xl">
-                <FlipLink href="https://x.com/Ethereum_Chile" text="Twitter">
+                <FlipLink href="https://x.com/ethereum_chile" text="Twitter">
                   Twitter
                 </FlipLink>
               </div>

--- a/src/components/SocialMediaIcons.tsx
+++ b/src/components/SocialMediaIcons.tsx
@@ -41,7 +41,7 @@ const SocialMediaIcons: React.FC = () => {
 
       {/* Twitter/X */}
       <a
-        href="https://twitter.com/ethchile"
+        href="https://x.com/ethereum_chile"
         target="_blank"
         rel="noopener noreferrer"
         className="group"

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -9,7 +9,7 @@ import { Icon } from 'astro-icon'
             ¡Síguenos en nuestras redes sociales y mantente al tanto de las últimas novedades de Ethereum!
         </p>
         <div class="flex w-full md:space-x-10 grow justify-between md:justify-center">
-            <a href="https://twitter.com/ethereum_chile">
+            <a href="https://x.com/ethereum_chile">
                 <Icon name="twitter" class="w-14 h-12 md:w-16 md:h-16">
             </a>
             <a href="https://t.me/ethereumchile">


### PR DESCRIPTION
## Summary
This PR fixes inconsistencies in Twitter/X links across the website by standardizing them to use the correct handle `@ethereum_chile`.

## Changes
- **SocialMediaIcons.tsx**: Updated from `@ethchile` to `@ethereum_chile`
- **Footer.tsx**: Fixed capitalization from `@Ethereum_Chile` to `@ethereum_chile`
- **Socials.astro**: Updated from `twitter.com` to `x.com` for consistency

## Result
All organization Twitter/X links now consistently use: `https://x.com/ethereum_chile`

Note: Personal team member handles remain unchanged as intended.